### PR TITLE
Add 64-bit support and fix ADODB field tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# use glob syntax
-syntax: glob
-
 *.obj
 *.pdb
 *.user
@@ -34,3 +31,4 @@ _ReSharper*/
 *.orig
 [Pp]ackages/
 BuildNuGetPackage/
+.vs/

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyCopyright("Copyright © ProductiveRage 2017")]
-[assembly: AssemblyVersion("1.9.3.0")]
-[assembly: AssemblyFileVersion("1.9.3.0")]
+[assembly: AssemblyVersion("1.9.4.0")]
+[assembly: AssemblyFileVersion("1.9.4.0")]

--- a/Tester/Tester.csproj
+++ b/Tester/Tester.csproj
@@ -65,10 +65,6 @@
       <Project>{05ca6867-a198-4952-883b-60c0a29c8bae}</Project>
       <Name>StageTwoParser</Name>
     </ProjectReference>
-    <ProjectReference Include="..\UnitTests\UnitTests.csproj">
-      <Project>{69946782-bab3-4c3f-ab64-a351998256e2}</Project>
-      <Name>UnitTests</Name>
-    </ProjectReference>
     <ProjectReference Include="..\LegacyParser\LegacyParser.csproj">
       <Project>{a9d32e0b-f434-4b08-a883-a62c5be5131a}</Project>
       <Name>LegacyParser</Name>

--- a/UnitTests/RuntimeSupport/Implementations/VBScriptEsqueValueRetrieverTests.cs
+++ b/UnitTests/RuntimeSupport/Implementations/VBScriptEsqueValueRetrieverTests.cs
@@ -990,7 +990,7 @@ namespace VBScriptTranslator.UnitTests.RuntimeSupport.Implementations
 				var fieldY = y as ADODB.Field;
 				if (fieldY == null)
 					throw new ArgumentException("y is not an ADODB.Field");
-				return fieldX.Value == fieldY.Value;
+				return fieldX.Value.Equals(fieldY.Value);
 			}
 
 			public int GetHashCode(object obj)

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VBScriptTranslator.UnitTests</RootNamespace>
     <AssemblyName>VBScriptTranslator.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
@@ -40,19 +42,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -211,15 +210,22 @@
       <Lcid>0</Lcid>
       <WrapperTool>primary</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/VBScriptTranslator.RuntimeSupport.nuspec
+++ b/VBScriptTranslator.RuntimeSupport.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>VBScriptTranslator.RuntimeSupport</id>
-    <version>1.9.3.0</version>
+    <version>1.9.4.0</version>
     <title>VBScript-to-C# Translator - RuntimeSupport library only</title>
     <authors>ProductiveRage</authors>
     <owners>ProductiveRage</owners>


### PR DESCRIPTION
This PR adds 64-bit support by using the correct size of the native `Variant` structure in IDispatchAccess.cs.

The conditional to determine if running on 32-bit or not (`IntPtr.Size == 4`) may seem arbitrary, but it matches exactly the condition Microsoft uses in the [reference source](https://referencesource.microsoft.com/#mscorlib/system/Runtime/InteropServices/Variant.cs) linked in the code.

This PR also fixes the unit tests so that they work in VS 2019 (albeit with many analyser warnings cause of the state of the tests), and fixes an issue with the ADODB field tests where it was using an incorrect equality check. 4 tests fail - these were failing before the changes here.

Finally .gitignore is added (since this repo is now using Git not Mercurial), and the version bumped to 1.9.4.

_We've been running this code since 2019 so it's had a lot of time working in production._